### PR TITLE
Modified to search found .csproj files instead of file name

### DIFF
--- a/dh.bat
+++ b/dh.bat
@@ -118,7 +118,12 @@ goto loop
 :HasCsprojFileWithTestFrameworkReferences
     set "directory=%~1"
     set "found=0"
-
+ 
+    if not exist "%directory%" (
+        echo Directory does not exist.
+        set "result=0"
+        goto :eof
+    )
     for %%f in ("%directory%\*.csproj") do (
         findstr /i /l "xunit nunit mstest" "%%f" > nul
         if !errorlevel! == 0 (

--- a/dh.bat
+++ b/dh.bat
@@ -7,22 +7,24 @@ set "currentDir=%cd%"
 set "index=1"
 ECHO ----DOTNET_CLIHUB----
 for /r "%cd%" %%d in (.) do (
-    if exist "%%d\*test*.csproj" (
-        set "relativeDir=%%d"
-        set "relativeDir=!relativeDir:%currentDir%=!"
-        REM set "relativeDir=!relativeDir:\=!"
-        set "relativeDir=!relativeDir:~1!"
-        set "relativeDir=!relativeDir:~0,-2!"
-        if !index! lss 10 (
-            echo !index!.  !relativeDir!
-        ) else (
-            echo !index!. !relativeDir!
+    if exist "%%d\**.csproj" (
+    call :HasCsprojFileWithTestFrameworkReferences "%%d"
+        if "!result!" == "1" (
+            set "relativeDir=%%d"
+            set "relativeDir=!relativeDir:%currentDir%=!"
+            REM set "relativeDir=!relativeDir:\=!"
+            set "relativeDir=!relativeDir:~1!"
+            set "relativeDir=!relativeDir:~0,-2!"
+            if !index! lss 10 (
+                echo !index!.  !relativeDir!
+            ) else (
+                echo !index!. !relativeDir!
+            )
+            set "dirList=!dirList! !relativeDir!"
+            set /a index+=1
         )
-        set "dirList=!dirList! !relativeDir!"
-        set /a index+=1
     )
 )
-
 :loop
 
 set /p userInput="  >> "
@@ -112,6 +114,20 @@ for %%d in (!dirList!) do (
 goto loop
 
 :exitloop
+
+:HasCsprojFileWithTestFrameworkReferences
+    set "directory=%~1"
+    set "found=0"
+
+    for %%f in ("%directory%\*.csproj") do (
+        findstr /i /l "xunit nunit mstest" "%%f" > nul
+        if !errorlevel! == 0 (
+            set result=1
+            goto :eof
+        )
+    )
+    set "result=0"
+    goto :eof
 
 REM The dotnet run needs to be executed here in order to have minimum amount of ctrl+c (interrupt) presses 
 if "%userInput%" == "r" (


### PR DESCRIPTION
Checks for the prescence of strings in any found .csproj files for the most popular .net testing frameworks: xunit, mstest and nunit. 